### PR TITLE
Lzc dev

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -215,3 +215,17 @@ export const getManageCompetitionList = (competitionId: number, pageNumber: numb
     url: '/admin/com/manager?comId=' + competitionId + '&pageNum=' + pageNumber + '&pageSize=' + pageSize,
   })
 }
+
+/**
+ * 导出附件
+ *
+ * @param competitionId 比赛Id
+ * @param userCode 队长学号
+ * @returns Axios 对象
+ */
+export const exportWorkFile = (competitionId: number, userCode: string) => {
+  return apis({
+    method: 'get',
+    url: '/admin/data/exportWork?comId=' + competitionId + '&userCode=' + userCode,
+  })
+}

--- a/src/pages/create/Components/reviewerSet/index.tsx
+++ b/src/pages/create/Components/reviewerSet/index.tsx
@@ -34,55 +34,59 @@ const ReviewSet: React.FC<reviewSetPropsType> = (props) => {
   const { Option } = Select
   return (
     <div className="activity-create-reviewer-setting">
-      <span className="activity-create-reviewer-code">审批者学号</span>
-      <Input
-        className="first"
-        placeholder="审批者学号"
-        value={value.value}
-        onChange={(e) => {
-          setValue(index, e.target.value)
-        }}
-        showCount={false}
-      />
-      <span className="activity-create-reviewer-faculty">审批学院代号</span>
-      {value.key === -1 ? (
-        <Select
-          className="last"
-          showSearch
-          placeholder="负责的审批的学院"
-          onSelect={(value: number) => setKey(index, value)}
-          filterOption={(input, option) =>
-            (option!.children as unknown as string).toLowerCase().includes(input.toLowerCase())
-          }
-        >
-          {a.map((value, index) => {
-            return (
-              <Option key={value + index} value={index + 1}>
-                {value}
-              </Option>
-            )
-          })}
-        </Select>
-      ) : (
-        <Select
-          className="last"
-          value={value.key}
-          showSearch
-          placeholder="负责的审批的学院"
-          onSelect={(value: number) => setKey(index, value)}
-          filterOption={(input, option) =>
-            (option!.children as unknown as string).toLowerCase().includes(input.toLowerCase())
-          }
-        >
-          {a.map((value, index) => {
-            return (
-              <Option key={value + index} value={index + 1}>
-                {value}
-              </Option>
-            )
-          })}
-        </Select>
-      )}
+      <div className="activity-create-reviewer-setting-code">
+        <span id="activity-create-reviewer-setting-code">审批者学号</span>
+        <Input
+          className="first"
+          placeholder="审批者学号"
+          value={value.value}
+          onChange={(e) => {
+            setValue(index, e.target.value)
+          }}
+          showCount={false}
+        />
+      </div>
+      <div className="activity-create-reviewer-setting-faculty">
+        <span id="activity-create-reviewer-setting-faculty">审批学院代号</span>
+        {value.key === -1 ? (
+          <Select
+            className="last"
+            showSearch
+            placeholder="负责的审批的学院"
+            onSelect={(value: number) => setKey(index, value)}
+            filterOption={(input, option) =>
+              (option!.children as unknown as string).toLowerCase().includes(input.toLowerCase())
+            }
+          >
+            {a.map((value, index) => {
+              return (
+                <Option key={value + index} value={index + 1}>
+                  {value}
+                </Option>
+              )
+            })}
+          </Select>
+        ) : (
+          <Select
+            className="last"
+            value={value.key}
+            showSearch
+            placeholder="负责的审批的学院"
+            onSelect={(value: number) => setKey(index, value)}
+            filterOption={(input, option) =>
+              (option!.children as unknown as string).toLowerCase().includes(input.toLowerCase())
+            }
+          >
+            {a.map((value, index) => {
+              return (
+                <Option key={value + index} value={index + 1}>
+                  {value}
+                </Option>
+              )
+            })}
+          </Select>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/pages/create/index.scss
+++ b/src/pages/create/index.scss
@@ -26,14 +26,15 @@ $vh_base: 1080;
   }
   .activity-create-header-buttons {
     display: flex;
-    justify-content: space-between;
+    // justify-content: space-between;
     align-self: stretch;
     align-items: flex-end;
-    margin-right: 93px;
+    margin-right: 3%;
     margin-left: auto;
     width: 300px;
     .ant-btn-primary {
       min-width: 74px;
+      margin:5px;
     }
     #activity-create-cancel {
       background-color: white;
@@ -90,16 +91,31 @@ $vh_base: 1080;
       }
     }
   }
-  .activity-create-name {
-    display: flex;
+  .activity-create-name-and-template {
     margin-left: 241px;
-    #activity-create-name {
-      height: 40px;
-      line-height: 40px;
-      width: 106px;
+    margin-bottom: 37px;
+    display: flex;
+    align-items: center;
+    .activity-create-name {
+      display: inline-block;
+      #activity-create-name {
+        display: inline-block;
+        width: 106px;
+      }
+      .ant-input {
+        width: 224px;
+      }
     }
-    .ant-input {
-      width: 263px;
+    .activity-template-select {
+      margin-left: 138px;
+      display: inline-block;
+      #activity-template-select {
+        display: inline-block;
+        width: 106px;
+      }
+      .ant-select {
+        width: 224px;
+      }
     }
   }
   .activity-create-type {
@@ -150,32 +166,58 @@ $vh_base: 1080;
       margin-left: 19px;
     }
   }
-  .other-setting{
+  .activity-create-reviewer-setting-default{
+    margin-left: 241px;
+    margin-bottom: 37px;
+    display: flex;
+    align-items: center;
+    .activity-create-reviewer-setting-default-code{
+      display: inline-block;
+      #activity-create-reviewer-setting-default-code{
+        display: inline-block;
+        width: 106px;
+      }
+    }
+    .activity-create-reviewer-setting-default-change-number{
+      margin-left: 138px;
+      display: inline-block;
+    }
+    .ant-input{
+      width: 224px;
+    }
+  }
+  .other-setting {
     flex-direction: column;
   }
-  .activity-create-reviewer-setting{
+  .activity-create-reviewer-setting {
+    margin-left: 241px;
+    margin-bottom: 37px;
     display: flex;
-    align-items: flex-start;
-    margin-left: 240px;
-    margin-bottom: 30px;
-    .activity-create-reviewer-faculty,.activity-create-reviewer-code{
-      width: 106px;
-      min-height: 14px;
-      color: rgba(128, 128, 128, 1);
-      padding: 5px 0 0 0;
+    align-items: center;
+    .activity-create-reviewer-setting-code {
+      display: inline-block;
+      #activity-create-reviewer-setting-code {
+        display: inline-block;
+        width: 106px;
+      }
     }
-    .first{
-      margin: 0 138px 0 0;
+    .activity-create-reviewer-setting-faculty {
+      margin-left: 138px;
+      display: inline-block;
+      #activity-create-reviewer-setting-faculty {
+        display: inline-block;
+        width: 106px;
+      }
     }
-    .last{
-      min-width: 224px;
+    .ant-select{
+      width: 224px;
     }
     .ant-input {
       width: 224px;
     }
   }
-  .manage-create-icon{
-    float:left;
+  .manage-create-icon {
+    float: left;
     margin: 2px;
     font-size: 28px;
   }

--- a/src/pages/manageDetail/components/dataTable/index.tsx
+++ b/src/pages/manageDetail/components/dataTable/index.tsx
@@ -1,6 +1,6 @@
 import { Dropdown, Menu, notification } from 'antd'
 import { UserOutlined } from '@ant-design/icons'
-import { fileDownload } from '../../../../api/public'
+import { exportWorkFile } from '../../../../api/admin'
 import React from 'react'
 
 const DataTable: React.FC<any> = (props) => {
@@ -40,25 +40,45 @@ const DataTable: React.FC<any> = (props) => {
         <span
           className="manage-detail-list-content-export"
           onClick={() => {
-            fileDownload(value.fileId).then((res) => {
-              const blob = new Blob([res.data])
-              const downloadElement = document.createElement('a')
-              const href = window.URL.createObjectURL(blob) //创建下载的链接
-              downloadElement.href = href
-              downloadElement.download = '作品' + value.fileName + '.zip' //下载后文件名
-              document.body.appendChild(downloadElement)
-              downloadElement.click() //点击下载
-              document.body.removeChild(downloadElement) //下载完成移除元素
-              window.URL.revokeObjectURL(href) //释放掉blob对象
-              setTimeout(() => {
-                notification.success({
-                  message: '😸️ 导出成功',
-                  description: '作品已成功导出',
-                  top: 20,
-                  placement: 'top',
-                })
-              }, 100)
-            })
+            exportWorkFile(value.comId, value.userCode)
+              .then((res) => {
+                if (res.data.sucess) {
+                  const blob = new Blob([res.data])
+                  const downloadElement = document.createElement('a')
+                  const href = window.URL.createObjectURL(blob) //创建下载的链接
+                  downloadElement.href = href
+                  downloadElement.download = '项目 ' + value.fileName + ' 的附件.zip' //下载后文件名
+                  document.body.appendChild(downloadElement)
+                  downloadElement.click() //点击下载
+                  document.body.removeChild(downloadElement) //下载完成移除元素
+                  window.URL.revokeObjectURL(href) //释放掉blob对象
+                  setTimeout(() => {
+                    notification.success({
+                      message: '😸️ 导出成功',
+                      description: '作品已成功导出',
+                      top: 20,
+                      placement: 'top',
+                    })
+                  }, 100)
+                } else {
+                  notification.error({
+                    message: ' 导出失败',
+                    description: res.data.errMsg,
+                    top: 20,
+                    placement: 'top',
+                  })
+                }
+              })
+              .catch((error) => {
+                setTimeout(() => {
+                  notification.error({
+                    message: ' 导出失败',
+                    description: error + '',
+                    top: 20,
+                    placement: 'top',
+                  })
+                }, 100)
+              })
           }}
         >
           导出

--- a/src/pages/manageDetail/index.tsx
+++ b/src/pages/manageDetail/index.tsx
@@ -18,7 +18,6 @@ import { useNavigate, useLocation } from 'react-router-dom'
 type DataType = {
   index: number
   comId: number
-  fileId: number
   fileName: string
   isAssignJudge: number
   judges: string[]

--- a/src/pages/workDetail/component/index.tsx
+++ b/src/pages/workDetail/component/index.tsx
@@ -1,11 +1,7 @@
-import React from 'react';
+import React from 'react'
 
 function Component() {
-  return (
-    <div>
-      Component
-    </div>
-  );
+  return <div>Component</div>
 }
 
-export default Component;
+export default Component

--- a/src/store/formTemplate.ts
+++ b/src/store/formTemplate.ts
@@ -1,0 +1,76 @@
+export const tempelate = [
+  {
+    type: 'object',
+    labelWidth: 120,
+    properties: {
+      是否为STITP项目: {
+        enum: ['是', '否'],
+        type: 'string',
+        title: '是否为STITP项目',
+        widget: 'radio',
+        required: true,
+        enumNames: ['是', '否'],
+        order: 1,
+      },
+      申报书: {
+        type: 'string',
+        widget: 'customUpload',
+        title: '申报书',
+        required: true,
+        props: {
+          inputName: '申报书',
+          accept: '.pdf',
+        },
+        order: 2,
+      },
+      研究报告: {
+        type: 'string',
+        widget: 'customUpload',
+        title: '研究报告',
+        required: true,
+        props: {
+          inputName: '研究报告',
+          accept: '.pdf',
+        },
+        order: 3,
+      },
+      作品简介书: {
+        type: 'string',
+        widget: 'customUpload',
+        title: '作品简介书',
+        required: true,
+        props: {
+          inputName: '作品简介书',
+          accept: '.pdf',
+        },
+        order: 4,
+      },
+      作品名称: {
+        type: 'string',
+        props: {},
+        title: '作品名称',
+        required: true,
+        order: 5,
+      },
+      作品类别: {
+        enum: ['自然科学类学术论文', '哲学社会科学类社会调查报告和学术论文', '科技发明制作A类', '科技发明制作B类'],
+        type: 'string',
+        title: '作品类别',
+        widget: 'select',
+        required: true,
+        enumNames: ['自然科学类学术论文', '哲学社会科学类社会调查报告和学术论文', '科技发明制作A类', '科技发明制作B类'],
+        order: 6,
+      },
+      作品简介: {
+        type: 'string',
+        props: {},
+        title: '作品简介',
+        format: 'textarea',
+        required: true,
+        order: 7,
+      },
+    },
+    displayType: 'column',
+  },
+]
+export const option = ['一号模板']

--- a/src/type/apiTypes.ts
+++ b/src/type/apiTypes.ts
@@ -6,7 +6,7 @@ export type competitionInfoType = {
   submit_end_time: string // 活动提交结束时间
   review_begin_time: string // 评审开始时间
   review_end_time: string // 评审结束时间
-  table: null // 文档中的注释："表单schema，我不知道是啥" 大概是为 xrender 设计的
+  table: object // 文档中的注释："表单schema，我不知道是啥" 大概是为 xrender 设计的
   type: number // 0 团队 1 个人
   min_team_members: number // 默认值：1 值：1 团队人数限制
   max_team_members: number // 值：2 团队人数限制


### PR DESCRIPTION
在 create 组件里增加了一个单选框来选择表单模板，表单模板数据存储在新建的文件夹的一个数组中。具体运作逻辑是根据单选框抛出的数字来获取数组中的表单
当修改活动时，逆向获取数组的 index 失败（类型不符导致 findIndex()报错） 故在单选框添加了 -1 值为 ‘不修改’，该选项仅在修改活动时出现，由 preSchema 的状态 控制 ，仅在修改活动时会赋值preSchema ，其余情况为空。